### PR TITLE
Corrected handling of dates before 3/1/1900

### DIFF
--- a/lib/dullard/reader.rb
+++ b/lib/dullard/reader.rb
@@ -241,6 +241,7 @@ class Dullard::Sheet
             when :datetime
             when :time
             when :date
+              value = value.to_f + 1 if value.to_f <= 60 # compensate for Microsoft's incorrect leap year calculation: see http://support.microsoft.com/kb/214326
               value = (DateTime.new(1899,12,30) + value.to_f)
             when :percentage # ? TODO
             when :float

--- a/lib/dullard/version.rb
+++ b/lib/dullard/version.rb
@@ -1,3 +1,3 @@
 module Dullard
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
Fixed handling of dates before 3/1/1900.
Microsoft stores dates as offsets from 1/1/900, however their algorithm incorrectly considers 1900 as a leap year.  
See http://support.microsoft.com/kb/214326
